### PR TITLE
Extend ActiveJob::Base to support apartment tenants

### DIFF
--- a/config/initializers/apartment_activejob.rb
+++ b/config/initializers/apartment_activejob.rb
@@ -1,0 +1,6 @@
+require 'active_job'
+require 'active_job_tenant'
+
+class ActiveJob::Base
+  include ActiveJobTenant
+end

--- a/lib/active_job_tenant.rb
+++ b/lib/active_job_tenant.rb
@@ -1,0 +1,46 @@
+module ActiveJobTenant
+  extend ActiveSupport::Concern
+
+  included do
+    attr_accessor :tenant
+
+    attr_writer :current_account
+  end
+
+  module ClassMethods
+    def deserialize(job_data)
+      super.tap do |job|
+        job.tenant = job_data['tenant']
+        job.current_account = nil
+      end
+    end
+  end
+
+  def serialize
+    super.merge('tenant' => Apartment::Tenant.current)
+  end
+
+  def perform_now
+    switch do
+      super
+    end
+  end
+
+  private
+
+    def current_account
+      @current_account ||= Account.find_by(tenant: current_tenant)
+    end
+
+    def current_tenant
+      tenant || Apartment::Tenant.current
+    end
+
+    def switch
+      Apartment::Tenant.switch(current_tenant) do
+        current_account.switch! if current_account
+
+        yield
+      end
+    end
+end

--- a/spec/lib/active_job_tenant_spec.rb
+++ b/spec/lib/active_job_tenant_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe ActiveJobTenant do
+  before do
+    allow(Apartment::Tenant).to receive(:current).and_return('x')
+    allow(Apartment::Tenant).to receive(:switch).with('x') do |&block|
+      block.call
+    end
+  end
+
+  let(:account) { FactoryGirl.build(:account) }
+
+  before do
+    allow(Account).to receive(:find_by).with(tenant: 'x').and_return(account)
+  end
+
+  subject do
+    Class.new(ActiveJob::Base) do
+      def perform
+        current_account
+      end
+    end
+  end
+
+  describe 'tenant context' do
+    it 'switches to the tenant database' do
+      expect(Apartment::Tenant).to receive(:switch).with('x')
+
+      subject.perform_now
+    end
+
+    it 'switches the other account-based connection' do
+      expect(account).to receive(:switch!)
+
+      subject.perform_now
+    end
+
+    it 'evaluates in the context of a tenant and account' do
+      expect(subject.perform_now).to eq account
+    end
+  end
+
+  # mimics the `.perform_later` workflow
+  describe '.deserialize' do
+    let(:serialized_job) { subject.new.serialize.merge('job_class' => 'ActiveJob::Base') }
+    let(:delayed_subject) { subject.deserialize(serialized_job) }
+
+    it 'preserves the original tenant' do
+      expect(delayed_subject.tenant).to eq 'x'
+    end
+  end
+end


### PR DESCRIPTION
Fixes #55 

Using the general pattern from https://github.com/influitive/apartment-activejob, extend ActiveJob::Base to inject apartment and our own multitenancy requirements.