### PR TITLE
Install RIIIF to provide IIIF image API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,3 +82,5 @@ gem 'flip'
 gem 'lograge'
 
 gem 'zk'
+
+gem 'riiif', '~> 0.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -601,6 +601,8 @@ GEM
       rake
       resque (~> 1.22)
     retriable (1.4.1)
+    riiif (0.2.0)
+      rails (> 3.2.0)
     rolify (5.1.0)
     rsolr (1.0.13)
       builder (>= 2.1.2)
@@ -781,6 +783,7 @@ DEPENDENCIES
   peek-resque
   pg
   rails (= 4.2.6)
+  riiif (~> 0.2.0)
   rolify
   rsolr (~> 1.0.6)
   rspec

--- a/config/initializers/riiif.rb
+++ b/config/initializers/riiif.rb
@@ -1,0 +1,20 @@
+Riiif::Image.file_resolver = Riiif::HTTPFileResolver.new
+Riiif::Image.info_service = lambda do |_id, _file|
+  # resp = get_solr_response_for_doc_id id
+  # doc = resp.first['response']['docs'].first
+  { height: '', width: '' } # doc['height_isi'], width: doc['width_isi'] }
+end
+
+def logger
+  Rails.logger
+end
+
+Riiif::Image.file_resolver.id_to_uri = lambda do |id|
+  ActiveFedora::Base.id_to_uri(CGI.unescape(id)).tap do |url|
+    logger.info "Riiif resolved #{id} to #{url}"
+  end
+end
+# Riiif::Image.file_resolver.basic_auth_credentials = [ActiveFedora.fedora.user, ActiveFedora.fedora.password]
+
+Riiif::Engine.config.cache_duration_in_days = 365
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
   end
 
   mount Flip::Engine => '/admin/features'
+  mount Riiif::Engine => '/images'
 
   # This must be the very last route in the file because it has a catch-all route for 404 errors.
   # This behavior seems to show up only in production mode.


### PR DESCRIPTION
You can hit the image server by going to
http://localhost:3000/images/3t945r21d%2Ffiles%2F3a81f05c-5570-47a5-8f04-974317c20323/full/full/0/default.jpg

You can construct this ID by doing:
```ruby
fs = FileSet.find('3t945r21d')
CGI.escape(fs.original_file.id)
=> "3t945r21d%2Ffiles%2F3a81f05c-5570-47a5-8f04-974317c20323"
```

Fixes #112 