### PR TITLE
Simply multitenant account creation workflow

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,9 +45,7 @@ Rails/HasAndBelongsToMany:
     - 'app/models/role.rb'
 
 RSpec/AnyInstance:
-  Exclude:
-    - 'spec/requests/accounts_spec.rb'
-    - 'spec/requests/home_spec.rb'
+  Enabled: false
 
 RSpec/DescribeClass:
   Exclude:

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -15,7 +15,6 @@ class AccountsController < ApplicationController
 
   # GET /accounts/new
   def new
-    @account.assign_attributes tenant: request.host, cname: request.host
   end
 
   # GET /accounts/1/edit
@@ -27,8 +26,8 @@ class AccountsController < ApplicationController
   def create
     respond_to do |format|
       if CreateAccount.new(@account).save
-        format.html { redirect_to @account, notice: 'Account was successfully created.' }
-        format.json { render :show, status: :created, location: @account }
+        format.html { redirect_to first_user_registration_url, notice: 'Account was successfully created.' }
+        format.json { render :show, status: :created, location: @account.cname }
       else
         format.html { render :new }
         format.json { render json: @account.errors, status: :unprocessable_entity }
@@ -63,9 +62,17 @@ class AccountsController < ApplicationController
 
   private
 
+    def first_user_registration_url
+      new_user_registration_url(host: @account.cname)
+    end
+
+    def create_params
+      params.require(:account).permit(:name)
+    end
+
     # Never trust parameters from the scary internet, only allow the white list through.
     def account_params
-      params.require(:account).permit(:tenant, :cname,
+      params.require(:account).permit(:name, :cname,
                                       solr_endpoint_attributes: [:id, :url],
                                       fcrepo_endpoint_attributes: [:id, :url, :base_path])
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,7 +22,7 @@ class ApplicationController < ActionController::Base
   before_action :set_account_specific_connections!
 
   rescue_from Apartment::TenantNotFound do
-    redirect_to new_account_path
+    redirect_to splash_path
   end
 
   private
@@ -40,7 +40,7 @@ class ApplicationController < ActionController::Base
     end
 
     def multitenant?
-      Settings.multitenant
+      Settings.multitenancy.enabled
     end
 
     def current_account

--- a/app/controllers/splash_controller.rb
+++ b/app/controllers/splash_controller.rb
@@ -1,0 +1,6 @@
+class SplashController < ApplicationController
+  layout "multitenant"
+
+  def index
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,6 +1,7 @@
 # Customer organization account
 class Account < ActiveRecord::Base
   attr_readonly :tenant
+  validates :name, presence: true
   validates :tenant, presence: true, uniqueness: true
   validates :cname, presence: true, uniqueness: true
 
@@ -8,6 +9,11 @@ class Account < ActiveRecord::Base
   belongs_to :fcrepo_endpoint, dependent: :delete
 
   accepts_nested_attributes_for :solr_endpoint, :fcrepo_endpoint, update_only: true
+
+  before_validation do
+    self.tenant ||= SecureRandom.uuid
+    self.cname ||= Settings.multitenancy.default_host % { tenant: name.parameterize } if name
+  end
 
   # @return [Account]
   def self.from_request(request)

--- a/app/services/create_account.rb
+++ b/app/services/create_account.rb
@@ -9,8 +9,11 @@ class CreateAccount
   end
 
   def save
-    account.save &&
-      create_tenant &&
+    account.save && create_external_resources
+  end
+
+  def create_external_resources
+    create_tenant &&
       create_solr_collection &&
       create_fcrepo_endpoint &&
       account.save

--- a/app/views/accounts/_edit_form.html.erb
+++ b/app/views/accounts/_edit_form.html.erb
@@ -15,6 +15,7 @@
     <%= f.label :tenant %><br>
     <%= f.text_field :tenant, class: 'form-control', readonly: @account.persisted? %>
   </div>
+  
   <div class="form-group">
     <%= f.label :cname %><br>
     <%= f.text_field :cname, class: 'form-control' %>

--- a/app/views/accounts/_new_form.html.erb
+++ b/app/views/accounts/_new_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_for(@account, class: 'form') do |f| %>
+  <% if @account.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@account.errors.count, "error") %> prohibited this account from being saved:</h2>
+
+      <ul>
+      <% @account.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= f.label :name %><br>
+    <%= f.text_field :name, class: 'form-control' %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit class: 'btn btn-primary' %>
+  </div>
+<% end %>

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -1,6 +1,6 @@
 <h1>Editing Account</h1>
 
-<%= render 'form' %>
+<%= render 'edit_form' %>
 
 <%= link_to 'Show', @account %> |
 <%= link_to 'Back', accounts_path %>

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -1,5 +1,5 @@
 <h1>New Account</h1>
 
-<%= render 'form' %>
+<%= render 'new_form' %>
 
-<%= link_to 'Back', accounts_path %>
+<%= link_to 'Back', splash_path %>

--- a/app/views/layouts/multitenant.html.erb
+++ b/app/views/layouts/multitenant.html.erb
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="<%= t("sufia.document_language") %>">
+<head>
+  <%= render "layouts/head_tag_content"%>
+</head>
+
+<body>
+  
+<%= render '/masthead' %>
+<%= render '/flash_msg' %>
+
+<%= yield %>
+
+<%= render partial: '/footer' %>
+<%= render 'shared/ajax_modal' %>
+</body>
+</html>

--- a/app/views/splash/index.html.erb
+++ b/app/views/splash/index.html.erb
@@ -1,0 +1,9 @@
+<section id="banner" class="jumbotron">
+  <div class="container">
+    <h1><%= application_name %></h1>
+    <p><%= t('application.tagline') %></p>
+    <p>
+      <%= link_to 'Sign Up', new_account_path, class: 'btn btn-primary btn-lg' %>
+    </p>
+  </div>
+</section>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,3 +1,3 @@
 en:
   blacklight:
-    application_name: 'HyBox Repo'
+    application_name: 'Hydra in a Box'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,8 @@
 
 en:
   hello: "Hello world"
+  application:
+    tagline: The next-generation repository solution
 
   activerecord:
     attributes:

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -1,6 +1,6 @@
 en:
   sufia:
-    product_name: "HyBox Repo"
+    product_name: "Hydra in a Box"
     product_twitter_handle: "@HydraInABox"
     institution_name:   "Hydra in a Box"
     account_name:       "Hydra in a Box Account Id"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
   resources :accounts
   root 'sufia/homepage#index'
 
+  get 'splash', to: 'splash#index'
+
   mount Blacklight::Engine => '/'
   mount CurationConcerns::Engine, at: '/'
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,9 @@
-multitenant: false
+multitenancy:
+  enabled: false
+  default_host: "<%= ENV.fetch('SETTINGS__MULTITENANCY__DEFAULT_HOST', '%{tenant}.dev') %>"
 
 solr:
-  url: <%= ENV.fetch('SETTINGS__SOLR__URL', 'http://127.0.0.1:8983/solr/') %>
+  url: "<%= ENV.fetch('SETTINGS__SOLR__URL', 'http://127.0.0.1:8983/solr/') %>"
   configset: hybox
   configset_source_path: <%= File.join(Rails.root, 'solr', 'config') %>
   collection_options:
@@ -9,4 +11,4 @@ solr:
     numShards: 1
 
 zookeeper:
-  connection_str: <%= ENV.fetch('SETTINGS__ZOOKEEPER__CONNECTION_STR', 'localhost:9983/configs') %>
+  connection_str: "<%= ENV.fetch('SETTINGS__ZOOKEEPER__CONNECTION_STR', 'localhost:9983/configs') %>"

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,1 +1,2 @@
-multitenant: true
+multitenancy:
+  enabled: true

--- a/db/migrate/20160506091234_add_name_to_account.rb
+++ b/db/migrate/20160506091234_add_name_to_account.rb
@@ -1,0 +1,5 @@
+class AddFieldsToAccount < ActiveRecord::Migration
+  def change
+    add_column :accounts, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160427155928) do
+ActiveRecord::Schema.define(version: 20160506091234) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 20160427155928) do
     t.datetime "updated_at",         null: false
     t.integer  "solr_endpoint_id"
     t.integer  "fcrepo_endpoint_id"
+    t.string   "name"
   end
 
   add_index "accounts", ["cname", "tenant"], name: "index_accounts_on_cname_and_tenant", using: :btree

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe AccountsController, type: :controller do
   # Account. As you add validations to Account, be sure to
   # adjust the attributes here as well.
   let(:valid_attributes) do
-    { tenant: 'x', cname: 'example.com' }
+    { name: 'x' }
   end
 
   let(:valid_fcrepo_endpoint_attributes) do
@@ -56,14 +56,14 @@ RSpec.describe AccountsController, type: :controller do
 
     describe "POST #create" do
       context "with valid params" do
-        let(:create_service) { double(save: true) }
         before do
-          allow(CreateAccount).to receive(:new).with(Account).and_return(create_service)
+          allow_any_instance_of(CreateAccount).to receive(:create_external_resources)
         end
 
         it "creates a new Account" do
-          expect(create_service).to receive(:save).and_return(true)
-          post :create, { account: valid_attributes }, valid_session
+          expect do
+            post :create, { account: valid_attributes }, valid_session
+          end.to change(Account, :count).by(1)
         end
       end
 

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -1,6 +1,5 @@
 FactoryGirl.define do
   factory :account do
-    sequence(:cname) { |_n| "#{srand}.example.com" }
-    sequence(:tenant) { |_n| srand }
+    sequence(:name) { |_n| srand }
   end
 end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Account, type: :model do
 
   describe '.from_request' do
     let(:request) { double(host: 'example.com') }
-    let!(:account) { described_class.create(tenant: 'example', cname: 'example.com') }
+    let!(:account) { described_class.create(name: 'example', tenant: 'example', cname: 'example.com') }
 
     it 'retrieves the account that matches the incoming request' do
       expect(described_class.from_request(request)).to eq account

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe 'Home page', type: :request do
 
   context 'without a current tenant' do
     before do
-      allow(Settings).to receive(:multitenant).and_return(true)
+      allow(Settings).to receive(:multitenancy).and_return(double(enabled: true))
     end
 
     describe 'GET /' do
       it 'redirects to the accounts landing page' do
         get root_path
-        expect(response).to redirect_to(new_account_path)
+        expect(response).to redirect_to(splash_path)
       end
     end
   end

--- a/spec/views/accounts/edit.html.erb_spec.rb
+++ b/spec/views/accounts/edit.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "accounts/edit", type: :view do
-  let(:account) { Account.create! tenant: "MyString", cname: "MyString" }
+  let(:account) { FactoryGirl.create(:account) }
 
   before(:each) do
     assign(:account, account)

--- a/spec/views/accounts/index.html.erb_spec.rb
+++ b/spec/views/accounts/index.html.erb_spec.rb
@@ -1,25 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe "accounts/index", type: :view do
+  let(:account_a) { FactoryGirl.create(:account) }
+  let(:account_b) { FactoryGirl.create(:account) }
+
   before(:each) do
-    assign(:accounts, [
-             Account.create!(
-               tenant: "Tenant",
-               cname: "Cname"
-             ),
-             Account.create!(
-               tenant: "Tenant 2",
-               cname: "Cname 2"
-             )
-           ])
+    assign(:accounts, [account_a, account_b])
   end
 
   it "renders a list of accounts" do
     render
-    assert_select "tr>td", text: "Tenant".to_s
-    assert_select "tr>td", text: "Cname".to_s
+    assert_select "tr>td", text: account_a.tenant.to_s
+    assert_select "tr>td", text: account_a.cname.to_s
 
-    assert_select "tr>td", text: "Tenant 2".to_s
-    assert_select "tr>td", text: "Cname 2".to_s
+    assert_select "tr>td", text: account_b.tenant.to_s
+    assert_select "tr>td", text: account_b.cname.to_s
   end
 end

--- a/spec/views/accounts/new.html.erb_spec.rb
+++ b/spec/views/accounts/new.html.erb_spec.rb
@@ -3,8 +3,7 @@ require 'rails_helper'
 RSpec.describe "accounts/new", type: :view do
   before(:each) do
     assign(:account, Account.new(
-                       tenant: "MyString",
-                       cname: "MyString"
+                       name: "MyString"
     ))
   end
 
@@ -12,9 +11,7 @@ RSpec.describe "accounts/new", type: :view do
     render
 
     assert_select "form[action=?][method=?]", accounts_path, "post" do
-      assert_select "input#account_tenant[name=?]", "account[tenant]"
-
-      assert_select "input#account_cname[name=?]", "account[cname]"
+      assert_select "input#account_name[name=?]", "account[name]"
     end
   end
 end

--- a/spec/views/accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/show.html.erb_spec.rb
@@ -1,16 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe "accounts/show", type: :view do
+  let(:account) { FactoryGirl.create(:account) }
+
   before(:each) do
-    @account = assign(:account, Account.create!(
-                                  tenant: "Tenant",
-                                  cname: "Cname"
-    ))
+    @account = assign(:account, account)
   end
 
   it "renders attributes in <p>" do
     render
-    expect(rendered).to match(/Tenant/)
-    expect(rendered).to match(/Cname/)
+    expect(rendered).to include(account.tenant)
+    expect(rendered).to include(account.cname)
   end
 end


### PR DESCRIPTION
- add a simple splash page
- only require an account name, and generate default settings for other params
- use a uuid for account tenant identifier
- use a local subdomain, and push custom cnames to editing account

![screen shot 2016-05-06 at 10 49 52 am](https://cloud.githubusercontent.com/assets/111218/15076551/49fc3bb0-1378-11e6-9dd0-f780bb675af2.png)
