### PR TITLE
Pass the hostname from the request to IIIF

### DIFF
--- a/app/builders/manifest_helper.rb
+++ b/app/builders/manifest_helper.rb
@@ -2,12 +2,12 @@ class ManifestHelper
   include Rails.application.routes.url_helpers
   include ActionDispatch::Routing::PolymorphicRoutes
 
-  def polymorphic_url(record, opts = {})
-    opts[:host] ||= host
-    super(record, opts)
+  def initialize(hostname)
+    @hostname = hostname
   end
 
-  def host
-    Rails.application.config.action_mailer.default_url_options[:host]
+  def polymorphic_url(record, opts = {})
+    opts[:host] ||= @hostname
+    super(record, opts)
   end
 end

--- a/app/controllers/curation_concerns/file_sets_controller.rb
+++ b/app/controllers/curation_concerns/file_sets_controller.rb
@@ -1,0 +1,6 @@
+module CurationConcerns
+  class FileSetsController < ApplicationController
+    include CurationConcerns::FileSetsControllerBehavior
+    self.show_presenter = Hybox::FileSetPresenter
+  end
+end

--- a/app/controllers/curation_concerns/generic_works_controller.rb
+++ b/app/controllers/curation_concerns/generic_works_controller.rb
@@ -17,6 +17,13 @@ module CurationConcerns
       end
     end
 
+    protected
+
+      # Overrideing to pass in a third argument, the hostname. Used for IIIF manifest
+      def presenter
+        @presenter ||= show_presenter.new(curation_concern_from_search_results, current_ability, request.base_url)
+      end
+
     private
 
       def manifest_builder

--- a/app/presenters/concerns/displays_image.rb
+++ b/app/presenters/concerns/displays_image.rb
@@ -17,21 +17,17 @@ module DisplaysImage
 
     def display_image_url(original_file, size = '600,')
       Riiif::Engine.routes.url_helpers.image_url(original_file.id,
-                                                 host: manifest_helper.host,
+                                                 host: @hostname,
                                                  size: size)
     end
 
     def base_image_url(original_file)
-      uri = Riiif::Engine.routes.url_helpers.info_url(original_file.id, host: manifest_helper.host)
+      uri = Riiif::Engine.routes.url_helpers.info_url(original_file.id, host: @hostname)
       # TODO: There should be a riiif route for this:
       uri.sub(%r{/info\.json\Z}, '')
     end
 
     def iiif_endpoint(original_file)
       IIIFManifest::IIIFEndpoint.new(base_image_url(original_file), profile: "http://iiif.io/api/image/2/level2.json")
-    end
-
-    def manifest_helper
-      @manifest_helper ||= ManifestHelper.new
     end
 end

--- a/app/presenters/curation_concerns/generic_work_show_presenter.rb
+++ b/app/presenters/curation_concerns/generic_work_show_presenter.rb
@@ -1,4 +1,11 @@
 class CurationConcerns::GenericWorkShowPresenter < Sufia::WorkShowPresenter
+  self.file_presenter_class = Hybox::FileSetPresenter
+
+  def initialize(solr_document, ability, hostname)
+    super(solr_document, ability)
+    @hostname = hostname
+  end
+
   def manifest_url
     manifest_helper.polymorphic_url([:manifest, self])
   end
@@ -6,6 +13,6 @@ class CurationConcerns::GenericWorkShowPresenter < Sufia::WorkShowPresenter
   private
 
     def manifest_helper
-      @manifest_helper ||= ManifestHelper.new
+      @manifest_helper ||= ManifestHelper.new(@hostname)
     end
 end

--- a/app/presenters/hybox/file_set_presenter.rb
+++ b/app/presenters/hybox/file_set_presenter.rb
@@ -1,0 +1,10 @@
+module Hybox
+  class FileSetPresenter < CurationConcerns::FileSetPresenter
+    include DisplaysImage
+
+    def initialize(solr_document, ability, hostname)
+      super(solr_document, ability)
+      @hostname = hostname
+    end
+  end
+end

--- a/config/initializers/file_set_displays_image.rb
+++ b/config/initializers/file_set_displays_image.rb
@@ -1,1 +1,0 @@
-CurationConcerns::FileSetPresenter.include DisplaysImage

--- a/spec/controllers/curation_concerns/file_sets_controller_spec.rb
+++ b/spec/controllers/curation_concerns/file_sets_controller_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe CurationConcerns::FileSetsController do
+  describe 'show_presenter' do
+    subject { described_class.show_presenter }
+    it { is_expected.to eq Hybox::FileSetPresenter }
+  end
+end

--- a/spec/controllers/curation_concerns/generic_works_controller_spec.rb
+++ b/spec/controllers/curation_concerns/generic_works_controller_spec.rb
@@ -23,4 +23,16 @@ RSpec.describe CurationConcerns::GenericWorksController do
       expect(response.body).to eq "{\"test\":\"manifest\"}"
     end
   end
+
+  describe "#presenter" do
+    let(:solr_document) { SolrDocument.new(FactoryGirl.create(:generic_work).to_solr) }
+    before do
+      allow(controller).to receive(:curation_concern_from_search_results).and_return(solr_document)
+    end
+    subject { controller.send :presenter }
+    it "initializes a presenter" do
+      expect(subject).to be_kind_of CurationConcerns::GenericWorkShowPresenter
+      expect(subject.manifest_url).to eq "http://test.host/concern/generic_works/#{solr_document.id}/manifest"
+    end
+  end
 end

--- a/spec/presenters/curation_concerns/generic_work_show_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/generic_work_show_presenter_spec.rb
@@ -3,11 +3,17 @@ require 'rails_helper'
 RSpec.describe CurationConcerns::GenericWorkShowPresenter do
   let(:document) { { "has_model_ssim" => ['GenericWork'], 'id' => '99' } }
   let(:solr_document) { SolrDocument.new(document) }
+  let(:hostname) { 'http://test.host' }
   let(:ability) { nil }
-  let(:presenter) { described_class.new(solr_document, ability) }
+  let(:presenter) { described_class.new(solr_document, ability, hostname) }
 
   describe "#manifest_url" do
     subject { presenter.manifest_url }
-    it { is_expected.to eq 'http://test.com/concern/generic_works/99/manifest' }
+    it { is_expected.to eq 'http://test.host/concern/generic_works/99/manifest' }
+  end
+
+  describe "file_presenter_class" do
+    subject { described_class.file_presenter_class }
+    it { is_expected.to eq Hybox::FileSetPresenter }
   end
 end

--- a/spec/presenters/hybox/file_set_presenter_spec.rb
+++ b/spec/presenters/hybox/file_set_presenter_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 require 'iiif_manifest'
-RSpec.describe CurationConcerns::FileSetPresenter do
+RSpec.describe Hybox::FileSetPresenter do
   let(:file_set) { FactoryGirl.create(:file_set) }
   let(:solr_document) { SolrDocument.new(file_set.to_solr) }
-  let(:presenter) { described_class.new(solr_document, nil) }
+  let(:presenter) { described_class.new(solr_document, nil, 'http://test.host') }
   let(:id) { CGI.escape(file_set.original_file.id) }
   before do
     Hydra::Works::AddFileToFileSet.call(file_set,
@@ -15,14 +15,14 @@ RSpec.describe CurationConcerns::FileSetPresenter do
     subject { presenter.display_image }
     it "creates a display image" do
       expect(subject).to be_instance_of IIIFManifest::DisplayImage
-      expect(subject.url).to eq "http://test.com/images/#{id}/full/600,/0/default.jpg"
+      expect(subject.url).to eq "http://test.host/images/#{id}/full/600,/0/default.jpg"
     end
   end
 
   describe "iiif_endpoint" do
     subject { presenter.send(:iiif_endpoint, file_set.original_file) }
     it 'returns the url' do
-      expect(subject.url).to eq "http://test.com/images/#{id}"
+      expect(subject.url).to eq "http://test.host/images/#{id}"
     end
   end
 end


### PR DESCRIPTION
Manifest generator needs a host, but we also need to support
multitenant. This passes the host through the controllers to the
presenters where it's needed to draw IIIF manifests.

Fixes #177 