### PR TITLE
Update dependencies, including Riiif 0.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,8 +45,8 @@ group :development, :test do
   gem 'solr_wrapper', '~> 0.10'
   gem 'fcrepo_wrapper', '~> 0.4'
 
-  gem 'rubocop'
-  gem 'rubocop-rspec'
+  gem 'rubocop', '~> 0.39.0'
+  gem 'rubocop-rspec', '~> 1.4.1'
 end
 
 group :development do
@@ -59,7 +59,7 @@ end
 
 gem 'blacklight', '~> 6.2'
 gem 'sufia', git: 'https://github.com/projecthydra/sufia.git', branch: 'master'
-gem 'curation_concerns', git: 'https://github.com/projecthydra/curation_concerns.git', branch: 'factory_arguments'
+gem 'curation_concerns', git: 'https://github.com/projecthydra/curation_concerns.git', branch: 'master'
 gem 'rsolr', '~> 1.0.6'
 
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/projecthydra/curation_concerns.git
-  revision: 4f02820fb38350386bccf27f13f16c0b3b2200b5
-  branch: factory_arguments
+  revision: 97a4ce030d628dd531c8d7aaba91d3032435881d
+  branch: master
   specs:
     curation_concerns (1.0.0.beta3)
       active_attr
@@ -27,7 +27,7 @@ GIT
 
 GIT
   remote: https://github.com/projecthydra/sufia.git
-  revision: 9c1afba2bb55dbcfbec23b59e2505f1716cb2ba2
+  revision: 1e53af0daf8abfb1be521615389b60f2c8c9b07d
   branch: master
   specs:
     sufia (7.0.0.beta1)
@@ -188,7 +188,7 @@ GEM
       sass-rails
       skydrive
     builder (3.2.2)
-    byebug (9.0.3)
+    byebug (9.0.4)
     cancancan (1.14.0)
     capybara (2.7.1)
       addressable
@@ -246,7 +246,7 @@ GEM
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubis (2.7.0)
-    execjs (2.6.0)
+    execjs (2.7.0)
     extlib (0.9.16)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
@@ -600,7 +600,7 @@ GEM
     responders (2.2.0)
       railties (>= 4.2.0, < 5.1)
     retriable (1.4.1)
-    riiif (0.2.0)
+    riiif (0.2.1)
       rails (> 3.2.0)
     rolify (5.1.0)
     rsolr (1.0.13)
@@ -789,8 +789,8 @@ DEPENDENCIES
   rsolr (~> 1.0.6)
   rspec
   rspec-rails
-  rubocop
-  rubocop-rspec
+  rubocop (~> 0.39.0)
+  rubocop-rspec (~> 1.4.1)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   sidekiq


### PR DESCRIPTION
This new version of riiif does the prescribed redirect from the base
image route to the info.json route