### PR TITLE
Update Riiif to 0.2.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -600,7 +600,7 @@ GEM
     responders (2.2.0)
       railties (>= 4.2.0, < 5.1)
     retriable (1.4.1)
-    riiif (0.2.2)
+    riiif (0.2.3)
       rails (> 3.2.0)
     rolify (5.1.0)
     rsolr (1.0.13)


### PR DESCRIPTION
This fixes a bad route in riiif 0.2.2

```
NoMethodError (undefined method `info_path' for #<Riiif::ImagesController:0x0056376a120988>):
  riiif (0.2.2) app/controllers/riiif/images_controller.rb:37:in `redirect'
```