### PR TITLE
Fix link text color in masthead dropdown menu

### DIFF
--- a/app/assets/stylesheets/lerna.scss
+++ b/app/assets/stylesheets/lerna.scss
@@ -8,6 +8,10 @@ footer.navbar {
     color: $color-medium-gray;
     font-weight: 500;
   }
+
+  .dropdown-menu a {
+    color: $gray;
+  }
 }
 
 #masthead {


### PR DESCRIPTION
Fixes #257 

![index_dashboard____hydra-in-a-box](https://cloud.githubusercontent.com/assets/101482/15914138/46ad2ffc-2d93-11e6-9767-f546b3ff79e1.png)
